### PR TITLE
- Fix of html formatting on table title

### DIFF
--- a/DLLs/StringFunctions_DLL/string_functions.cpp
+++ b/DLLs/StringFunctions_DLL/string_functions.cpp
@@ -48,6 +48,8 @@
 #include "..\Debug_DLL\debug.h"
 #include "..\..\Shared\MagicNumbers\MagicNumbers.h"
 #include "Psapi.h"
+#include <string>
+#include <regex>
 
 const char kUnprintableBeepChar = 0x07;
 const char kCharToBeRemoved = kUnprintableBeepChar;
@@ -430,6 +432,12 @@ void RemoveExtraDotsInNumbers(CString *s) {
   }
   // Finally remove all superfluous characters
   s->Remove(kCharToBeRemoved);
+}
+
+void RemoveHtmlTagsAndContexts(CString* s) {
+    std::regex tags("<[^>]*>[^>]*<[^>]*>");
+    std::string remove{};
+    *s = std::regex_replace(s->GetString(), tags, remove).c_str();
 }
 
 void StringFunctionsTest() {

--- a/DLLs/StringFunctions_DLL/string_functions.h
+++ b/DLLs/StringFunctions_DLL/string_functions.h
@@ -33,6 +33,7 @@ STRING_FUNCTIONS_API CString Number2CString(double number, int default_precision
 // like currentbet0..currentbet9, separated by spaces
 STRING_FUNCTIONS_API CString RangeOfSymbols(CString format_string, int first, int last);
 STRING_FUNCTIONS_API void RemoveExtraDotsInNumbers(CString *s);
+STRING_FUNCTIONS_API void RemoveHtmlTagsAndContexts(CString* s);
 STRING_FUNCTIONS_API void RemoveLeftWhiteSpace(CString *s);
 STRING_FUNCTIONS_API void RemoveMultipleWhiteSpaces(CString *s);
 STRING_FUNCTIONS_API void RemoveOHReplayFrameNumber(CString *s);

--- a/OpenHoldem/CTableTitle.cpp
+++ b/OpenHoldem/CTableTitle.cpp
@@ -96,6 +96,7 @@ CString CTableTitle::PreprocessTitle(CString title) {
   RemoveSpacesInFrontOfCentMultipliers(&result);
   ReplaceCommasInNumbersByDots(&result);
   RemoveExtraDotsInNumbers(&result);
+  RemoveHtmlTagsAndContexts(&result);
   return result;
 }
 


### PR DESCRIPTION
Some casinos (especially now on iPoker network) sometimes have a bug and display table title with html formatting (html tags and contexts), so this patch fix them by removing those html formatting